### PR TITLE
Ubuntu 移除了 gunzip 指令到 gzip 的硬链接，修改 "gnuzip" 为 "gzip" 

### DIFF
--- a/socks5_install.sh
+++ b/socks5_install.sh
@@ -9,10 +9,10 @@ plain='\033[0m'
 
 install_gost(){
 apt update &&yum update
-apt install wget curl gunzip -y ||yum install wget curl gunzip -y
+apt install wget curl gzip -y ||yum install wget curl gunzip -y
 
 wget https://github.com/ginuerzh/gost/releases/download/v2.11.1/gost-linux-amd64-2.11.1.gz
-gunzip gost-linux-amd64-2.11.1.gz
+gzip gost-linux-amd64-2.11.1.gz
 mv gost-linux-amd64-2.11.1 /usr/local/bin/gost
 chmod +x /usr/local/bin/gost
 


### PR DESCRIPTION
Ubuntu 移除了 gunzip 指令到 gzip 的硬链接